### PR TITLE
Move configuration to local environment variable storage

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -1,0 +1,5 @@
+SECRET_KEY=''
+DB_AUTH=''
+DEBUG=true
+APP_KEY=''
+APP_SECRET=''

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,13 @@ target/
 
 # pyenv
 .python-version
+
+
+# Heroku local server development
+.env
+
+# Vagrant stuff
+.vagrant
+
+# PyCharm customizations
+.idea

--- a/README.md
+++ b/README.md
@@ -18,6 +18,35 @@ The token is configured as an environment variable (OS, or Heroku) with:
 
 export DB_AUTH=YOURKEYHERE
 (or a Heroku config variable called DB_AUTH)
-
+ 
 Running:
 python app.py runserver
+# DB_PROJECT_AUTO
+
+Requires:
+Python 2.7 +
+Pip
+
+Set up dependencies:
+virtualenv venv && source venv/bin/activate
+pip install -r requirements.txt
+
+Configuration:
+
+Configurations are loaded into the application through the use of environment variables (ENV).  When you run the app the values set in the `.env` file will get injected into the ENV so that the code can access them.  There is a sample file `.env.default` that you can use as a template to fill out the required environment variables in your own copy of the `.env` file.  For more information you read the [Heroku help doc](https://devcenter.heroku.com/articles/heroku-local).
+
+The Dropbox CORE api work is authenticated via OAuth. 
+A static business team token is required for so that non team admins may set up projects. 
+The token is configured as an environment variable (OS, or Heroku) with: 
+
+export DB_AUTH=YOURKEYHERE
+(or a Heroku config variable called DB_AUTH)
+
+Running:
+````shell
+# If you have the heroku command line tool chain you can use:
+$ heroku local
+
+# Otherwise:
+$ python app.py runserver
+````

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Set up dependencies:
 virtualenv venv && source venv/bin/activate
 pip install -r requirements.txt
 
+Configuration:
+
+Configurations are loaded into the application through the use of environment variables (ENV).  When you run the app the values set in the `.env` file will get injected into the ENV so that the code can access them.  There is a sample file `.env.default` that you can use as a template to fill out the required environment variables in your own copy of the `.env` file.  For more information you read the [Heroku help doc](https://devcenter.heroku.com/articles/heroku-local).
+
 The Dropbox CORE api work is authenticated via OAuth. 
 A static business team token is required for so that non team admins may set up projects. 
 The token is configured as an environment variable (OS, or Heroku) with: 

--- a/app.py
+++ b/app.py
@@ -19,8 +19,8 @@ from dropboxAPI import (get_info, get_team_members, get_dropbox_groups, get_user
 app = Flask(__name__)
 #Breaks Heroku
 #app.config['SECRET_KEY'] = os.urandom(24)
-app.config['SECRET_KEY'] = "w3xkIqP5nF6a8Ndq79J4rK5nK4MI/HM4kUJTB3PWa8cxmiqrxQZ/+hgp/d+gcV7e"
-app.config['DEBUG'] = True
+app.config['SECRET_KEY'] = os.environ['SECRET_KEY']
+app.config['DEBUG'] = os.environ['DEBUG']
 
 manager = Manager(app)
 bootstrap = Bootstrap(app)
@@ -29,17 +29,16 @@ moment = Moment(app)
 csrf = CsrfProtect()
 
 #Dropbox App
-APP_KEY = 'k543xq496hfjkqw'
-APP_SECRET = '6u1exxfq1aydw4m'
-
-#Static template folder till we get some front end code to do this:
-template_folder = "/Project_Automation_Template"
+APP_KEY = os.environ['APP_KEY']
+APP_SECRET = os.environ['APP_SECRET']
 
 #Read Dropbox Business API key from OS or Heroku config var:
 DB_BUSINESS_AUTH = os.environ['DB_AUTH']
 
-csrf_token = base64.urlsafe_b64encode(os.urandom(18))
+#Static template folder till we get some front end code to do this:
+template_folder = "/Project_Automation_Template"
 
+csrf_token = base64.urlsafe_b64encode(os.urandom(18))
 
 @app.route('/')
 def index():


### PR DESCRIPTION
This PR pulls out some of the hard coded configurations into the use of a .env file.  This is the suggested method from heroku. It makes it quite nice because you don't need to set the development environment variables by hand every time you run the server.
