### PR TITLE
Update redirect scheme and add auth protection for /main endpoint.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn app:app
+web: gunicorn app:app --timeout 60


### PR DESCRIPTION
- Add protection to the `GET|POST /main` endpoint to make sure the user has already logged in before visiting.  If they have not, we redirect the user to `/`.
- Add a new environment config to set whether the OAuth redirect is to an http or https url.
